### PR TITLE
macOS build fix

### DIFF
--- a/prboom2/data/rd_util.c
+++ b/prboom2/data/rd_util.c
@@ -102,6 +102,7 @@ size_t read_or_die(void **ptr, const char *file)
   }
 
   *ptr = buffer;
+  fclose(f);
   return length;
 }
 


### PR DESCRIPTION
This fixes the build on macOS (Intel/M1).  Before it was failing due to the file not closing and this stopped the build on the terminal (CMake, Unix Makefiles).